### PR TITLE
Missing using Plots in OLScontours.jl

### DIFF
--- a/Examples/NonlinearOptimization/OLScontours.jl
+++ b/Examples/NonlinearOptimization/OLScontours.jl
@@ -1,3 +1,4 @@
+using Plots
 # plots the contours of the OLS objective function,
 # with the true and estimated coefficients
 # generate data


### PR DESCRIPTION
When I ran the OLScontours.jl example, Julia would not recognize the commands because using Plots had not been specified.