### PR TITLE
Replace unicode minus with ascii hyphen in listing

### DIFF
--- a/econometrics.lyx
+++ b/econometrics.lyx
@@ -50702,7 +50702,7 @@ Mean dependent var   0.129001   S.D.
 
 \begin_layout Plain Layout
 
-Log-likelihood      −4396.923   Akaike criterion     8805.846
+Log-likelihood      -4396.923   Akaike criterion     8805.846
 \end_layout
 
 \begin_layout Plain Layout


### PR DESCRIPTION
The unicode minus in the program listing is not output in the final PDF, and causes a LyX warning message.

This commit replaces the unicode character with a simple ascii hyphen.