### PR TITLE
Fix output of OLS results for Nerlove model

### DIFF
--- a/econometrics.lyx
+++ b/econometrics.lyx
@@ -48,6 +48,10 @@
     breakautoindent=true, %
     captionpos=b%
 }
+
+\usepackage{newunicodechar}
+% for OLS output of Nerlove example (nerlove.out)
+\newunicodechar{σ}{\ensuremath{\sigma}}
 \end_preamble
 \options authordate
 \use_default_options false
@@ -58,7 +62,7 @@ theorems-ams-extended
 \maintain_unincluded_children false
 \language english
 \language_package default
-\inputencoding auto
+\inputencoding utf8
 \fontencoding global
 \font_roman "default" "default"
 \font_sans "default" "default"


### PR DESCRIPTION
Another unicode issue. Seems like it indeed makes sense to come up with a general approach since as you mentioned Julia also can output unicode.

This commit changes the document encoding to UTF-8, and then the unicode characters can be defined in the preamble using `\newunicodechar`. The disadvantage of this approach is that whenever a new unicode character causes an issue in the future, you have to manually define it in the preamble. e.g., this commit adds:

    \newunicodechar{σ}{\ensuremath{\sigma}}

If you are curious about the technical details (which are mostly over my head), this is a helpful post: https://tex.stackexchange.com/questions/377613/solve-unicode-char-is-not-set-up-for-use-with-latex-without-special-handling-o

If you do not like the approach of this commit, I currently see two alternatives:

1. Take the approach I took in the previous commit of manually changing the problematic characters to ASCII representations. e.g., literally put "sigma" instead of the sigma character.
2. You can switch to XeTeX or LuaTeX, which handle unicode characters a lot easier since any character that is supported by the font that is used can be used by them.

The following screenshot shows the change in PDF output after the commit in this pull request:

![nerlove-diff](https://github.com/mcreel/Econometrics/assets/1149353/10da7334-1a27-461c-95e6-8296df46db7e)
