### PR TITLE
Remove all 58 "latexpar" separators

### DIFF
--- a/econometrics.lyx
+++ b/econometrics.lyx
@@ -3000,10 +3000,6 @@ symmetric
 idempotent
 \emph default
 .
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -7745,10 +7741,6 @@ The region is an ellipse, since the CI for an individual coefficient defines
 
 \begin_layout Itemize
 From the picture we can see that:
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -8790,10 +8782,6 @@ Using the Chow test on the Nerlove model, we reject that there is coefficient
 \end_inset
 
 
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -8860,10 +8848,6 @@ where the sample size is 30,
 
  and 
 \begin_inset Formula $\epsilon\sim IIN(0,1)$
-\end_inset
-
-
-\begin_inset Separator latexpar
 \end_inset
 
 
@@ -9303,10 +9287,6 @@ Summary: When
 \end_inset
 
  is normally distributed:
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -9473,10 +9453,6 @@ Summary: Under strongly exogenous regressors, with
 \end_inset
 
  has the properties:
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -13144,10 +13120,6 @@ For the model
 \end_inset
 
 
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -14229,10 +14201,6 @@ formula
 \end_inset
 
 
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -14297,10 +14265,6 @@ iterated.
 \hat{\varepsilon}=y-X\hat{\theta}_{FGLS}
 \]
 
-\end_inset
-
-
-\begin_inset Separator latexpar
 \end_inset
 
 
@@ -14454,10 +14418,6 @@ y=(1-\alpha)X\beta+\alpha(Z\gamma)+\omega
  is zero.
  On the other hand, if the second model is correctly specified then 
 \begin_inset Formula $\alpha=1.$
-\end_inset
-
-
-\begin_inset Separator latexpar
 \end_inset
 
 
@@ -18944,10 +18904,6 @@ href{./Examples/Data/nerlove.data}{nerlove.data}
 \end_inset
 
 
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -18964,10 +18920,6 @@ Consider the model
 \ln C=\beta+\beta_{Q}\ln Q+\gamma_{Q}\left(\ln Q\right)^{2}+\beta_{L}\ln P_{L}+\beta_{F}\ln P_{F}+\beta_{K}\ln P_{K}+\epsilon
 \]
 
-\end_inset
-
-
-\begin_inset Separator latexpar
 \end_inset
 
 
@@ -19053,10 +19005,6 @@ href{./Examples/Data/hall.gdt}{hall.gdt}
  The return on investment defines wealth in the next period, and the process
  repeats.
  For the moment, explore the properties of the variables.
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -19147,10 +19095,6 @@ is a
 vector autoregressive
 \emph default
  model, of order 1 - commonly referred to as a VAR(1) model.
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -19265,10 +19209,6 @@ where
 \end_inset
 
 ).
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -19306,10 +19246,6 @@ test for autocorrelation using the test of your choice
 
 \begin_layout Enumerate
 repeat the above steps 10000 times.
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -20308,10 +20244,6 @@ OLS.
 \end_inset
 
  Using the rules
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -21336,10 +21268,6 @@ These results are valid assuming that the only identifying information comes
  restrictions, and through the use of a normalization.
  There are other sorts of identifying information that can be used.
  These include
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -22730,10 +22658,6 @@ assuming normality of the errors
 One can calculate the FIML estimator by iterating the 3SLS estimator, thus
  avoiding the use of a nonlinear optimizer.
  The steps are
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -31801,10 +31725,6 @@ reference "subsec:MEPS data"
 \end_inset
 
 ) 
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -37639,10 +37559,6 @@ Suppose we have an independently and identically distributed sample of size
 
  follows this exponential distribution.
  
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -37948,10 +37864,6 @@ For the Poisson model, the density
 
 .
  
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -38099,10 +38011,6 @@ Assume a d.g.p.
 
 .
  
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -38168,10 +38076,6 @@ href{./Examples/OLS/Nerlove.jl}{Nerlove.jl}
 
 \begin_layout Enumerate
 Using the fmincon routine in Econometrics
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -38514,10 +38418,6 @@ For the Poisson model, the density
 
 .
  The example EstimatePoisson.jl, in the notes, should be helpful
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -40630,10 +40530,6 @@ estimator that minimizes
 \end_inset
 
 
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -41211,10 +41107,6 @@ sufficiently rapidly
 
 \begin_layout Itemize
 this will be consistent, provided that
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -46252,10 +46144,6 @@ y_{i}=x_{i}^{\prime}\beta_{0}+\epsilon_{i}
 \end_inset
 
 
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -46269,10 +46157,6 @@ Suppose that
  Use this information to propose a GMM estimator that is equivalent to the
  OLS estimator.
  Your answer should include:
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -46306,10 +46190,6 @@ Now, suppose that
 \end_inset
 
 .
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -46328,10 +46208,6 @@ Propose a consistent GMM estimator of the parameter vector
 
  that uses this information.
  Your answer should include:
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -46612,10 +46488,6 @@ href{./Examples/NonlinearOptimization/EstimateLogit.jl}{EstimateLogit.jl}
 
  should prove quite helpful.
  
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -46684,10 +46556,6 @@ Verify the missing steps needed to show that
 \begin_layout Enumerate
 For the portfolio example, experiment with the program using lags of 3 and
  4 periods to define instruments
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -46937,10 +46805,6 @@ The variables
 \end_inset
 
 .
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -47015,17 +46879,6 @@ p_{n}^{\prime}(\theta) & q_{n}^{\prime}(\theta)\end{array}\right]^{\prime}$
 \end_inset
 
  and the corresponding true optimal weight matrix.
-\family default
-\series default
-\shape default
-\size default
-\bar default
-\color inherit
-
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -47149,10 +47002,6 @@ where
 
  is strictly exogenous: it is uncorrelated with the two epsilons at all
  time periods.
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -47420,10 +47269,6 @@ For the logit model, the probability
 \end_inset
 
  is the complement.
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -47709,10 +47554,6 @@ For the Poisson model, the density
 
 .
  
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -47925,10 +47766,6 @@ where
 
 .
  This is a case of omitted relevant variables.
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -47967,10 +47804,6 @@ simulate data from the correct AR2 model, using
 \end_inset
 
  Use a sample size of 30 observations.
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -50478,10 +50311,6 @@ autoregressive part
 \begin_layout Itemize
 the model also requires restrictions for positive variance and stationarity,
  which are:
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -51923,10 +51752,6 @@ Write a Matlab/Julia/your favorite package script that generates two independent
 \end_inset
 
 
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -52888,17 +52713,6 @@ trick is
 \noun off
 \color none
  when in general we can't compute the posterior.
-\family default
-\series default
-\shape default
-\size default
-\bar default
-\color inherit
-
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -53154,10 +52968,6 @@ From this, we see that the information needed to determine if a proposal
 \end_inset
 
 .
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -53221,10 +53031,6 @@ for
 \end_inset
 
  
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -53294,10 +53100,6 @@ the art of applying these methods consists of providing a good proposal
  to sample from the posterior.
  However, we don't know the posterior, which is why we are doing MCMC in
  the first place....
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -54722,10 +54524,6 @@ For example, if
 \end_inset
 
  are not independent.
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_layout Itemize
@@ -55457,10 +55255,6 @@ Evidence that the two estimators are converging to different limits is evidence
 A Hausman test statistic can be computed, using the difference between the
  two estimators.
  
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -55839,10 +55633,6 @@ For
 \end_inset
 
  we cannot compute the moment conditions.
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -56087,10 +55877,6 @@ taking care of this problem is annoying without using a well written panel
 \end_deeper
 \begin_layout Itemize
 estimate fixed effects
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -56141,10 +55927,6 @@ do nonparametric density plot of fixed effects: mean is 1, but significant
 \end_deeper
 \begin_layout Itemize
 run random effects (tradition, but not logic, demands that we do it)
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -56454,10 +56236,6 @@ reference "eq:simple linear panel random effects"
 \end_inset
 
 .
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -57702,10 +57480,6 @@ n\gamma_{n}^{k}V\left[\hat{h}(x)\right] & = & n\gamma_{n}^{k}\frac{1}{n^{2}}\sum
 
 \begin_layout Itemize
 By the representative term argument, this is
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -60109,10 +59883,6 @@ edit kernel_example
 \end_inset
 
 .
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -60144,10 +59914,6 @@ help kernel_regression
 \end_inset
 
 .
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -60808,10 +60574,6 @@ This is a generalization of what we get from the classical model with normality,
 \end_inset
 
 : 
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper
@@ -67490,10 +67252,6 @@ With the same data,
  scope of this course.
  Nevertheless, the improvement in the likelihood function is considerable.
  The parameter estimates are
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_layout Standard
@@ -80423,10 +80181,6 @@ Define
 \end_inset
 
  is the Moore-Penrose generalized inverse.
-\begin_inset Separator latexpar
-\end_inset
-
-
 \end_layout
 
 \begin_deeper


### PR DESCRIPTION
This is a cleanup patch. It does affect the spacing in the PDF output. It's not an important patch, so if you prefer to keep them, that's completely fine.

Here's a screenshot of one of the squiggly latexpar separators (see the beginning of the selection), so you know this patch is referring to:

![squiggly-separators](https://github.com/mcreel/Econometrics/assets/1149353/a5e13ed9-c8ec-4249-a9aa-237450df5f0d)
