### PR TITLE
Organize preamble and remove some interword spaces

### DIFF
--- a/econometrics.lyx
+++ b/econometrics.lyx
@@ -6,16 +6,10 @@
 \origin unavailable
 \textclass extreport
 \begin_preamble
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \usepackage{lmodern}
-\usepackage[T1]{fontenc}
-\usepackage{graphicx}
-\usepackage{amsmath}
 \usepackage{dcolumn}
-%\usepackage[ps2pdf,pdftitle={Econometrics},urlcolor=blue,linktocpage,a4paper,colorlinks=true]{hyperref}
 \usepackage{listings}
 \usepackage{color}
-\usepackage{setspace}
 %
 \definecolor{hellgelb}{rgb}{1,1,0.8}
 \definecolor{colKeys}{rgb}{0,0,1}

--- a/econometrics.lyx
+++ b/econometrics.lyx
@@ -18,31 +18,6 @@
 \definecolor{colString}{rgb}{0,0.5,0}
 \let\endtitlepage\relax
 
-\lstset{%
-   morekeywords={AND,ASC,avg,CHECK,COMMIT,count,DECODE,DESC,DISTINCT,%
-                 GROUP,IN,LIKE,NUMBER,ROLLBACK,SUBSTR,sum,VARCHAR2}%
-}
-\lstset{%
-    float=hbp,%
-    basicstyle=\ttfamily\small, %
-    identifierstyle=\color{colIdentifier}, %
-    keywordstyle=\color{colKeys}, %
-    stringstyle=\color{colString}, %
-    commentstyle=\color{colComments}, %
-    columns=flexible, %
-    tabsize=2, %
-    frame=single, %
-    extendedchars=true, %
-    showspaces=false, %
-    showstringspaces=false, %
-    numbers=left, %
-    numberstyle=\tiny, %
-    breaklines=true, %
-    backgroundcolor=\color{hellgelb}, %
-    breakautoindent=true, %
-    captionpos=b%
-}
-
 \usepackage{newunicodechar}
 % for OLS output of Nerlove example (nerlove.out)
 \newunicodechar{σ}{\ensuremath{\sigma}}
@@ -129,6 +104,7 @@ theorems-ams-extended
 \papercolumns 1
 \papersides 1
 \paperpagestyle empty
+\listings_params "morekeywords={AND,ASC,avg,CHECK,COMMIT,count,DECODE,DESC,DISTINCT,GROUP,IN,LIKE,NUMBER,ROLLBACK,SUBSTR,sum,VARCHAR2},float=hbp,basicstyle={\ttfamily\small},identifierstyle={\color{colIdentifier}},keywordstyle={\color{colKeys}},stringstyle={\color{colString}},commentstyle={\color{colComments}},columns=flexible,tabsize=2,frame=single,extendedchars=true,showspaces=false,showstringspaces=false,numbers=left,numberstyle={\tiny},breaklines=true,backgroundcolor={\color{hellgelb}},breakautoindent=true,captionpos=b"
 \tracking_changes false
 \output_changes false
 \html_math_output 0

--- a/econometrics.lyx
+++ b/econometrics.lyx
@@ -4216,20 +4216,7 @@ Var(\hat{\beta}) & = & E\left\{ \left(\mathbf{\hat{\beta}-\beta}\right)\left(\ma
 \end_layout
 
 \begin_layout Standard
-The OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator is a 
+The OLS estimator is a 
 \emph on
 linear estimator
 \emph default
@@ -4897,20 +4884,7 @@ COMPANY, COST
 
  
 \series bold
-PRICE
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-OF LABOR
+PRICE OF LABOR
 \series default
  
 \begin_inset Formula $(P_{L})$
@@ -4918,20 +4892,7 @@ OF LABOR
 
 , 
 \series bold
-PRICE OF
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-FUEL
+PRICE OF FUEL
 \series default
  
 \begin_inset Formula $(P_{F})$
@@ -4939,20 +4900,7 @@ FUEL
 
  and 
 \series bold
-PRICE OF
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-CAPITAL
+PRICE OF CAPITAL
 \series default
  
 \begin_inset Formula $(P_{K}).$
@@ -5128,21 +5076,9 @@ Fortunately, Gretl and my OLS program agree upon the results.
 
 \begin_layout Standard
 The previous properties hold for finite sample sizes.
- Before considering the asymptotic properties of the OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator it is useful to review the MLE estimator, since under the assumption
- of normal errors the two estimators coincide.
+ Before considering the asymptotic properties of the OLS estimator it is
+ useful to review the MLE estimator, since under the assumption of normal
+ errors the two estimators coincide.
 \end_layout
 
 \begin_layout Section
@@ -5588,20 +5524,7 @@ The estimators are the same, under the present assumptions.
  Therefore, their properties are the same.
  
 \emph on
-In particular, under the classical assumptions with normality, the OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator
+In particular, under the classical assumptions with normality, the OLS estimator
 \emph default
  
 \begin_inset Formula $\hat{\beta}$
@@ -7080,21 +7003,8 @@ Score-type tests are based upon the general principle that the gradient
  vector of the unrestricted model, evaluated at the restricted estimate,
  should be asymptotically normally distributed with mean zero, if the restrictio
 ns are true.
- The original development was for ML
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimation, but the principle is valid for a wide variety of estimation
- methods.
+ The original development was for ML estimation, but the principle is valid
+ for a wide variety of estimation methods.
  
 \end_layout
 
@@ -7232,20 +7142,8 @@ R^{\prime}\hat{\lambda}=X^{\prime}y-X^{\prime}X\hat{\beta}_{R}
 
 \end_inset
 
- and the rhs is simply the gradient (score)
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-of the unrestricted model, evaluated at the restricted estimator.
+ and the rhs is simply the gradient (score) of the unrestricted model, evaluated
+ at the restricted estimator.
  The scores evaluated at the unrestricted estimate are identically zero.
  The logic behind the score test is that the scores evaluated at the restricted
  estimate should be approximately zero, if the restriction is true.
@@ -8681,20 +8579,8 @@ The restrictions are rejected at all conventional significance levels.
 \begin_layout Standard
 Since the restrictions are rejected, we should probably use the unrestricted
  model for analysis.
- What is the pattern of RTS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-as a function of the output group (small to large)? Figure 
+ What is the pattern of RTS as a function of the output group (small to
+ large)? Figure 
 \begin_inset CommandInset ref
 LatexCommand ref
 reference "Nerlove RTS"
@@ -9322,20 +9208,7 @@ Case 2
 
 
 \emph on
-
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-nonnormally distributed, strongly exogenous regressors
+ nonnormally distributed, strongly exogenous regressors
 \end_layout
 
 \begin_layout Standard
@@ -10535,20 +10408,7 @@ In the extreme, if there are exact linear relationships (every element of
 \begin_inset Formula $X^{\prime}X$
 \end_inset
 
- is not invertible and the OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator is not uniquely defined.
+ is not invertible and the OLS estimator is not uniquely defined.
  For example, if the model is 
 \begin_inset Formula 
 \begin{eqnarray*}
@@ -11200,21 +11060,9 @@ The last of these cases is collinearity.
 Intuitively, when there are strong linear relations between the regressors,
  it is difficult to determine the separate influence of the regressors on
  the dependent variable.
- This can be seen by comparing the OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-objective function in the case of no correlation between regressors with
- the objective function with correlation between the regressors.
+ This can be seen by comparing the OLS objective function in the case of
+ no correlation between regressors with the objective function with correlation
+ between the regressors.
  See the figures nocollin.ps (no correlation) and collin.ps (correlation),
  available on the web site.
 \end_layout
@@ -11622,20 +11470,8 @@ kv
 \end_inset
 
  artificial observations have no weight in the objective function, so the
- estimator has the same limiting objective function as the OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator, and is therefore consistent.
+ estimator has the same limiting objective function as the OLS estimator,
+ and is therefore consistent.
 \end_layout
 
 \begin_layout Standard
@@ -12107,21 +11943,8 @@ y_{t} & = & \left(x_{t}-v_{t}\right)^{\prime}\beta+\varepsilon_{t}\\
 
 \end_inset
 
- Because of this correlation, the OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator is biased and inconsistent, just as in the case of autocorrelated
- errors with lagged dependent variables.
+ Because of this correlation, the OLS estimator is biased and inconsistent,
+ just as in the case of autocorrelated errors with lagged dependent variables.
  In matrix notation, write the estimated model as 
 \begin_inset Formula 
 \[
@@ -12593,20 +12416,7 @@ y_{1}\\
 
 \end_inset
 
- Recall that the OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-fonc are 
+ Recall that the OLS fonc are 
 \begin_inset Formula 
 \[
 X^{\prime}X\hat{\beta}=X^{\prime}y
@@ -12614,20 +12424,8 @@ X^{\prime}X\hat{\beta}=X^{\prime}y
 
 \end_inset
 
- so if we regressed using only the first (complete)
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-observations, we would have 
+ so if we regressed using only the first (complete) observations, we would
+ have 
 \begin_inset Formula 
 \[
 X_{1}^{\prime}X_{1}\hat{\beta}_{1}=X_{1}^{\prime}y_{1.}
@@ -12635,20 +12433,8 @@ X_{1}^{\prime}X_{1}\hat{\beta}_{1}=X_{1}^{\prime}y_{1.}
 
 \end_inset
 
- Likewise, an OLS regression using only the second (filled in)
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-observations would give 
+ Likewise, an OLS regression using only the second (filled in) observations
+ would give 
 \begin_inset Formula 
 \[
 X_{2}^{\prime}X_{2}\hat{\beta}_{2}=X_{2}^{\prime}\hat{y}_{2}.
@@ -12922,20 +12708,7 @@ X_{2}
 \end_inset
 
  then we are in the case of errors of observation.
- As before, this means that the OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator is biased when 
+ As before, this means that the OLS estimator is biased when 
 \begin_inset Formula $X_{2}^{*}$
 \end_inset
 
@@ -13922,20 +13695,8 @@ FGLS estimation of a translog model
 \end_layout
 
 \begin_layout Standard
-So, this model has heteroscedasticity and autocorrelation, so OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-won't be efficient.
+So, this model has heteroscedasticity and autocorrelation, so OLS won't
+ be efficient.
  The next question is: how do we estimate efficiently using FGLS? FGLS is
  based upon inverting the estimated error covariance 
 \begin_inset Formula $\hat{\Sigma}.$
@@ -14086,20 +13847,8 @@ y^{\ast}=X^{\ast}\theta+\varepsilon^{\ast}
 
 \end_inset
 
- This is a consistent estimator, following the consistency of OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-and applying a LLN.
+ This is a consistent estimator, following the consistency of OLS and applying
+ a LLN.
 \end_layout
 
 \begin_layout Enumerate
@@ -14126,33 +13875,8 @@ Next compute the Cholesky factorization
 \end_layout
 
 \begin_layout Enumerate
-Finally the FGLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator can be calculated by applying OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-to the transformed model 
+Finally the FGLS estimator can be calculated by applying OLS to the transformed
+ model 
 \begin_inset Formula 
 \[
 \hat{P}^{\prime}y^{\ast}=\hat{P}^{\prime}X^{\ast}\theta+\hat{\hat{P}^{\prime}}\varepsilon^{\ast}
@@ -14160,20 +13884,7 @@ to the transformed model
 
 \end_inset
 
- or by directly using the GLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-formula 
+ or by directly using the GLS formula 
 \begin_inset Formula 
 \[
 \hat{\theta}_{FGLS}=\left(X^{\ast\prime}\left(\hat{\Sigma}_{0}^{\ast}\right)^{-1}X^{\ast}\right)^{-1}X^{\ast\prime}\left(\hat{\Sigma}_{0}^{\ast}\right)^{-1}y^{\ast}
@@ -14258,20 +13969,7 @@ These might be expected to lead to a better estimate than the estimator
 \begin_inset Formula $\hat{\theta}_{OLS},$
 \end_inset
 
- since FGLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-is asymptotically more efficient.
+ since FGLS is asymptotically more efficient.
  Then re-estimate 
 \begin_inset Formula $\theta$
 \end_inset
@@ -15083,20 +14781,7 @@ V(\varepsilon^{*}) & = & I_{n}
 \end_inset
 
  satisfies the classical assumptions.
- The GLS estimator is simply OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-applied to the transformed model: 
+ The GLS estimator is simply OLS applied to the transformed model: 
 \begin_inset Formula 
 \begin{eqnarray*}
 \hat{\beta}_{GLS} & = & (X^{*\prime}X^{*})^{-1}X^{*\prime}y^{*}\\
@@ -15110,33 +14795,8 @@ applied to the transformed model:
 \end_layout
 
 \begin_layout Standard
-The GLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator is unbiased in the same circumstances under which the OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator is unbiased.
+The GLS estimator is unbiased in the same circumstances under which the
+ OLS estimator is unbiased.
  For example, assuming 
 \begin_inset Formula $X$
 \end_inset
@@ -15206,33 +14866,7 @@ Tests are valid, using the previous formulas, as long as we substitute
 \end_layout
 
 \begin_layout Itemize
-The GLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator is more efficient than the OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator.
+The GLS estimator is more efficient than the OLS estimator.
  This is a consequence of the Gauss-Markov theorem, since the GLS estimator
  is based on a model that satisfies the classical assumptions but the OLS
  estimator is not.
@@ -15262,20 +14896,8 @@ where
 \end_layout
 
 \begin_layout Itemize
-As one can verify by calculating first order conditions, the GLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator is the solution to the minimization problem 
+As one can verify by calculating first order conditions, the GLS estimator
+ is the solution to the minimization problem 
 \begin_inset Formula 
 \[
 \hat{\beta}_{GLS}=\arg\min(y-X\beta)^{\prime}\Sigma^{-1}(y-X\beta)
@@ -15421,20 +15043,7 @@ parameterize
 \begin_inset Formula $\widehat{\Sigma},$
 \end_inset
 
- we obtain the FGLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator.
+ we obtain the FGLS estimator.
  
 \series bold
 The FGLS estimator shares the same asymptotic properties as GLS.
@@ -15628,20 +15237,7 @@ OLS with heteroscedastic consistent varcov estimation
 \begin_layout Standard
 Eicker (1967) and White (1980) showed how to modify test statistics to account
  for heteroscedasticity of unknown form.
- The OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator has asymptotic distribution 
+ The OLS estimator has asymptotic distribution 
 \begin_inset Formula 
 \[
 \sqrt{n}\left(\hat{\beta}-\beta\right)\overset{d}{\rightarrow}N\left(0,Q_{X}^{-1}\Omega Q_{X}^{-1}\right)
@@ -16060,20 +15656,8 @@ Perhaps a middle ground is to attempt to use GLS when severe HET is detected,
 
 \begin_layout Standard
 We'll consider two examples.
- Before this, let's consider the general nature of GLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-when there is heteroscedasticity.
+ Before this, let's consider the general nature of GLS when there is heterosceda
+sticity.
  When we have HET but no AUT, 
 \begin_inset Formula $\Sigma$
 \end_inset
@@ -16324,20 +15908,8 @@ y_{t}^{*}=x_{t}^{*\prime}\beta+\varepsilon_{t}^{*}.
 \end_layout
 
 \begin_layout Itemize
-This model is a bit complex in that NLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-is required to estimate the model of the variance.
+This model is a bit complex in that NLS is required to estimate the model
+ of the variance.
  A simpler version would be 
 \begin_inset Formula 
 \begin{eqnarray*}
@@ -17466,20 +17038,7 @@ Again the covariance matrix has a simple structure that depends on only
 \begin_inset Formula $\phi$
 \end_inset
 
- using OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-on 
+ using OLS on 
 \begin_inset Formula 
 \[
 \hat{\varepsilon}_{t}=u_{t}+\phi u_{t-1}
@@ -17570,19 +17129,7 @@ To solve this problem, estimate the covariance of
 
 \begin_layout Itemize
 Now solve these two equations to obtain identified (and therefore consistent)
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimators of both 
+ estimators of both 
 \begin_inset Formula $\phi$
 \end_inset
 
@@ -18123,20 +17670,8 @@ Finally, since
 \begin_inset Formula $\widehat{Q_{X}}=\frac{1}{n}X^{\prime}X$
 \end_inset
 
- to consistently estimate the limiting distribution of the OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator under heteroscedasticity and autocorrelation of unknown form.
+ to consistently estimate the limiting distribution of the OLS estimator
+ under heteroscedasticity and autocorrelation of unknown form.
  With this, asymptotically valid tests are constructed in the usual way.
 \end_layout
 
@@ -18333,20 +17868,7 @@ reference "fig:Durbin-Watson-critical-values"
 \end_layout
 
 \begin_layout Itemize
-Note that DW
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-can be used to test for nonlinearity (add discussion).
+Note that DW can be used to test for nonlinearity (add discussion).
  
 \end_layout
 
@@ -18403,20 +17925,8 @@ Lagged dependent variables and autocorrelation
 \end_layout
 
 \begin_layout Standard
-We've seen that the OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator is consistent under autocorrelation, as long as 
+We've seen that the OLS estimator is consistent under autocorrelation, as
+ long as 
 \begin_inset Formula $plim\frac{X^{\prime}\varepsilon}{n}=0.$
 \end_inset
 
@@ -18490,20 +18000,7 @@ plim\hat{\beta}=\beta+plim\frac{X^{\prime}\varepsilon}{n}
 
 \end_inset
 
- the OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator is inconsistent in this case.
+ the OLS estimator is inconsistent in this case.
  One needs to estimate by instrumental variables (IV), which we'll get to
  later
 \end_layout
@@ -19466,20 +18963,8 @@ Now consider whether
 
 \end_inset
 
- Because of this correlation, weak exogeneity does not hold, and OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimation of the demand equation will be biased and inconsistent.
+ Because of this correlation, weak exogeneity does not hold, and OLS estimation
+ of the demand equation will be biased and inconsistent.
  The same applies to the supply equation, for the same reason.
 \end_layout
 
@@ -20062,20 +19547,8 @@ all
 \end_layout
 
 \begin_layout Standard
-It may seem odd that we use OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-on the reduced form, since the rf equations are correlated, because 
+It may seem odd that we use OLS on the reduced form, since the rf equations
+ are correlated, because 
 \begin_inset Formula $\Xi\equiv\left(\Gamma^{-1}\right)^{\prime}\Sigma\Gamma^{-1}$
 \end_inset
 
@@ -21547,20 +21020,7 @@ Important note: OLS on the transformed model can be used to calculate the
 the OLS covariance formula is not valid.
 
 \emph default
- We need to apply the IV
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-covariance formula already seen above.
+ We need to apply the IV covariance formula already seen above.
  
 \end_layout
 
@@ -21576,20 +21036,7 @@ Actually, there is also a simplification of the general IV variance formula.
 
 \end_inset
 
- The IV
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-covariance estimator would ordinarily be 
+ The IV covariance estimator would ordinarily be 
 \begin_inset Formula 
 \[
 \hat{V}(\hat{\delta})=\left(\hat{Z}^{\prime}Z\right)^{-1}\left(\hat{Z}^{\prime}\hat{Z}\right)\left(Z^{\prime}\hat{Z}\right)^{-1}\hat{\sigma}_{IV}^{2}
@@ -21703,21 +21150,8 @@ is part of the specification of the model
 \end_layout
 
 \begin_layout Standard
-The IV
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator can be calculated by applying OLS to the transformed model, so
- the IV objective function at the minimized value is 
+The IV estimator can be calculated by applying OLS to the transformed model,
+ so the IV objective function at the minimized value is 
 \begin_inset Formula 
 \[
 s(\hat{\beta}_{IV})=\left(y-X\hat{\beta}_{IV}\right)^{\prime}P_{W}\left(y-X\hat{\beta}_{IV}\right),
@@ -22280,20 +21714,8 @@ y=Z\delta+\varepsilon
 
 \end_inset
 
- The 3SLS estimator is just 2SLS combined with a GLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-correction that takes advantage of the structure of 
+ The 3SLS estimator is just 2SLS combined with a GLS correction that takes
+ advantage of the structure of 
 \begin_inset Formula $\Psi.$
 \end_inset
 
@@ -22381,20 +21803,7 @@ The 2SLS estimator would be
  as can be verified by simple multiplication, and noting that the inverse
  of a block-diagonal matrix is just the matrix with the inverses of the
  blocks on the main diagonal.
- This IV
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator still ignores the covariance information.
+ This IV estimator still ignores the covariance information.
  The natural extension is to add the GLS transformation, putting the inverse
  of the error covariance into the formula, which gives the 3SLS estimator
  
@@ -22493,20 +21902,7 @@ reference "eq:2sls varcov"
 
 \end_inset
 
-), combined with the GLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-correction.
+), combined with the GLS correction.
 \end_layout
 
 \begin_layout Itemize
@@ -22535,21 +21931,8 @@ name "subsec:FIML"
 
 \begin_layout Standard
 Full information maximum likelihood is an alternative estimation method.
- FIML will be asymptotically efficient, since ML
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimators based on a given information set are asymptotically efficient
- w.r.t.
+ FIML will be asymptotically efficient, since ML estimators based on a given
+ information set are asymptotically efficient w.r.t.
  all other estimators that use the same information set, and in the case
  of the full-information ML estimator we use the entire information set.
  The 2SLS and 3SLS estimators don't require distributional assumptions,
@@ -22728,20 +22111,7 @@ Repeat steps 2-4 until there is no change in the parameters.
 
 \end_deeper
 \begin_layout Itemize
-FIML is fully efficient, since it's an ML
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator that uses all information.
+FIML is fully efficient, since it's an ML estimator that uses all information.
  This implies that 3SLS is fully efficient 
 \emph on
 when the errors are normally distributed.
@@ -23187,20 +22557,7 @@ D_{\theta}s(\theta)=b+C\theta
 
 \end_inset
 
-so the maximizing (minimizing)
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-element would be 
+so the maximizing (minimizing) element would be 
 \begin_inset Formula $\hat{\theta}=-C^{-1}b.$
 \end_inset
 
@@ -24059,20 +23416,7 @@ Another variation of quasi-Newton methods is to approximate the Hessian
  (in the dimension of the parameter vector) more costly than calculation
  of the gradient.
  They can be done to ensure that the approximation is p.d.
- DFP
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-and BFGS are two well-known examples.
+ DFP and BFGS are two well-known examples.
  
 \begin_inset Newpage newpage
 \end_inset
@@ -24255,33 +23599,7 @@ ensure
  
 \series bold
 \color red
-THIS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-IS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-IMPORTANT in practice.
+THIS IS IMPORTANT in practice.
 
 \series default
 \color inherit
@@ -27482,20 +26800,7 @@ reference "Consistency of ee"
 
 \end_inset
 
- can be used to prove strong consistency of the OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator.
+ can be used to prove strong consistency of the OLS estimator.
  There are easier ways to show this, of course - this is only an example
  of application of the theorem.
  
@@ -33258,20 +32563,7 @@ Regularity conditions
  not become infinite.
  We don't assume any particular set here, since the appropriate assumptions
  will depend upon the particularities of a given model.
- However, we assume that a SLLN
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-applies.
+ However, we assume that a SLLN applies.
 \end_layout
 
 \begin_layout Standard
@@ -33457,20 +32749,7 @@ As long as the
 \begin_inset Formula $g_{t}$
 \end_inset
 
- have finite variances, a CLT
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
- will apply.
+ have finite variances, a CLT  will apply.
  Checking this requires knowing what specific model we're working with,
  so for this general treatment, we will assume that the model satisfies
  this condition.
@@ -33540,20 +32819,7 @@ literal "false"
 
  
 \emph on
-The MLE
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator is asymptotically normally distributed.
+The MLE estimator is asymptotically normally distributed.
 \end_layout
 
 \begin_layout Itemize
@@ -34654,20 +33920,7 @@ Now, take the RHS, and differentiate.
 \series bold
 any
 \series default
- CAN
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator, is an identity matrix.
+ CAN estimator, is an identity matrix.
  Using this, suppose the variance of 
 \begin_inset Formula $\sqrt{n}\left(\tilde{\theta}-\theta\right)$
 \end_inset
@@ -34778,20 +34031,7 @@ the individual variances of each
 \emph on
 lower bound
 \emph default
- for the asymptotic variance of a CAN
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator.
+ for the asymptotic variance of a CAN estimator.
 \end_layout
 
 \begin_layout Standard
@@ -39018,20 +38258,7 @@ overidentification,
 The idea behind GMM is to combine information from the two moment conditions
  to form a new estimator which will be
 \emph on
-
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-more efficient,
+ more efficient,
 \emph default
  in general (proof of this below).
 \end_layout
@@ -40313,20 +39540,7 @@ We have already seen that the choice of
 \begin_inset Formula $W$
 \end_inset
 
- matrix to make the GMM
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator efficient 
+ matrix to make the GMM estimator efficient 
 \emph on
 within the class of GMM estimators
 \emph default
@@ -40366,20 +39580,7 @@ The generalized least square estimator minimizes the objective function
 \begin_layout Itemize
 The GLS optimal weighting matrix is seen to be the inverse of the covariance
  matrix of the errors.
- A similar result holds for GMM
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimation.
+ A similar result holds for GMM estimation.
  
 \end_layout
 
@@ -40397,33 +39598,8 @@ status collapsed
 
 \end_inset
 
-this presentation of GLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-is not a GMM
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator as defined above, because if we take the errors as 
+this presentation of GLS is not a GMM estimator as defined above, because
+ if we take the errors as 
 \begin_inset Quotes sld
 \end_inset
 
@@ -40444,20 +39620,7 @@ reference "GMM estimator (defn)"
 \end_inset
 
 .
- Later we'll see that GLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-can be expressed in the GMM framework.
+ Later we'll see that GLS can be expressed in the GMM framework.
  
 \begin_inset Newpage newpage
 \end_inset
@@ -40477,20 +39640,7 @@ If
 \begin_inset Formula $\hat{\theta}$
 \end_inset
 
- is a GMM
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator that minimizes 
+ is a GMM estimator that minimizes 
 \begin_inset Formula $\bar{m}_{n}(\theta)^{\prime}W_{n}\bar{m}_{n}(\theta),$
 \end_inset
 
@@ -42506,20 +41656,7 @@ The formula used to estimate the variance of
 \begin_layout Standard
 
 \series bold
-The GIV
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator is
+The GIV estimator is
 \end_layout
 
 \begin_layout Enumerate
@@ -42608,20 +41745,7 @@ When we have two sets of instruments,
 
 \begin_layout Itemize
 The penalty for indiscriminate use of instruments is that the small sample
- bias of the IV
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator rises as the number of instruments increases.
+ bias of the IV estimator rises as the number of instruments increases.
  The reason for this is that 
 \begin_inset Formula $P_{Z}X$
 \end_inset
@@ -43622,38 +42746,12 @@ In the introduction we argued that ML will in general be more efficient
 
  moment conditions may contain more information than others, since the moment
  conditions could be highly correlated.
- A GMM
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator that chose an optimal set of 
+ A GMM estimator that chose an optimal set of 
 \begin_inset Formula $P$
 \end_inset
 
  moment conditions would be fully efficient.
- The optimal moment conditions are simply the scores of the ML
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator.
+ The optimal moment conditions are simply the scores of the ML estimator.
 \end_layout
 
 \begin_layout Standard
@@ -61778,23 +60876,10 @@ Motivation
 \end_layout
 
 \begin_layout Standard
-Simulation methods are of interest when the DGP
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-is fully characterized by a parameter vector, so that simulated data can
- be generated, but the likelihood function and/or analytic moments of the
- observable variables are not calculable, so that ordinary MLE or GMM estimation
- is not possible.
+Simulation methods are of interest when the DGP is fully characterized by
+ a parameter vector, so that simulated data can be generated, but the likelihood
+ function and/or analytic moments of the observable variables are not calculable
+, so that ordinary MLE or GMM estimation is not possible.
  
 \end_layout
 
@@ -62231,20 +61316,7 @@ Often this will not be possible.
 \begin_inset Formula $\Pr(Y=y_{i}|X_{i}),$
 \end_inset
 
- which is then used to do ML
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimation.
+ which is then used to do ML estimation.
 \end_layout
 
 \begin_deeper
@@ -62459,20 +61531,7 @@ literal "true"
 \end_layout
 
 \begin_layout Itemize
-This means that the SML
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator is asymptotically biased if 
+This means that the SML estimator is asymptotically biased if 
 \begin_inset Formula $H$
 \end_inset
 
@@ -62532,20 +61591,8 @@ Suppose we have a data generating process DGP
 \end_layout
 
 \begin_layout Standard
-A formulation of the GMM
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator which we have studied is based upon the moment conditions 
+A formulation of the GMM estimator which we have studied is based upon the
+ moment conditions 
 \begin_inset Formula $m_{t}=z_{t}\epsilon_{t}(\theta)$
 \end_inset
 
@@ -62695,20 +61742,8 @@ noprefix "false"
 \end_inset
 
 , to highlight that simulations are used.
- With this simple difference, we form the GMM
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-criterion and estimate as usual.
+ With this simple difference, we form the GMM criterion and estimate as
+ usual.
  Note that the unbiased simulator 
 \begin_inset Formula $k(\widetilde{y}_{t}^{h},x_{t})$
 \end_inset
@@ -62744,20 +61779,8 @@ literal "true"
 
 \end_inset
 
- show that the asymptotic distribution of the MSM
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator is very similar to that of the infeasible GMM estimator.
+ show that the asymptotic distribution of the MSM estimator is very similar
+ to that of the infeasible GMM estimator.
  In particular, assuming that the optimal weighting matrix is used, and
  for 
 \begin_inset Formula $H$
@@ -63033,20 +62056,7 @@ E\ln(\tilde{p}_{i}(\beta,\Omega))\neq\ln(\mathcal{E}\tilde{p}_{i}(\beta,\Omega))
 \end_inset
 
  is a nonlinear transformation.
- The only way for the two to be equal (in the limit)
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-is if 
+ The only way for the two to be equal (in the limit) is if 
 \begin_inset Formula $H$
 \end_inset
 
@@ -64629,20 +63639,7 @@ each
 \begin_inset Formula $Y=X\beta^{0}+\varepsilon,$
 \end_inset
 
- the OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator 
+ the OLS estimator 
 \begin_inset Formula $\hat{\beta}_{n}=\left(X^{\prime}X\right)^{-1}X^{\prime}Y,$
 \end_inset
 
@@ -65597,19 +64594,7 @@ The choice of which moments upon which to base a GMM estimator can have
 \begin_layout Itemize
 A poor choice of moment conditions may lead to very inefficient estimators,
  and can even cause identification problems (as we've seen with the GMM
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-problem set).
+ problem set).
 \end_layout
 
 \begin_layout Itemize
@@ -66083,20 +65068,8 @@ Now, combining the results for the first and second terms,
  when the model is simulable.
  On the other hand, if the score generator is taken to be correctly specified,
  the ordinary estimator of the information matrix is consistent.
- Combining this with the result on the efficient GMM
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-weighting matrix in Theorem 
+ Combining this with the result on the efficient GMM weighting matrix in
+ Theorem 
 \begin_inset CommandInset ref
 LatexCommand ref
 reference "efficient weighting matrix"
@@ -66122,21 +65095,8 @@ reference "efficient weighting matrix"
 If one has used the Gallant-Nychka ML estimator as the auxiliary model,
  the appropriate weighting matrix is simply the information matrix of the
  auxiliary model, since the scores are uncorrelated.
- (e.g., it really is ML
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimation asymptotically, since the score generator can approximate the
- unknown density arbitrarily well).
+ (e.g., it really is ML estimation asymptotically, since the score generator
+ can approximate the unknown density arbitrarily well).
  
 \end_layout
 
@@ -67111,20 +66071,7 @@ reference "cap:Life-expectancy-of"
 \end_inset
 
  presents fitted life expectancy (expected additional years of life) as
- a function of age, with 95%
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-confidence bands.
+ a function of age, with 95% confidence bands.
  The plot is accompanied by a nonparametric Kaplan-Meier estimate of life-expect
 ancy.
  This nonparametric estimator simply averages all spell lengths greater
@@ -67716,20 +66663,7 @@ s_{n}(\theta) & = & \frac{1}{n}\sum_{t=1}^{n}\ln f_{t}(\mathbf{y}_{t}|\mathbf{Y}
 
 \end_inset
 
- and the QML
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-is 
+ and the QML is 
 \begin_inset Formula 
 \[
 \hat{\theta}_{n}=\arg\max_{\Theta}s_{n}(\theta)
@@ -68016,20 +66950,7 @@ D_{\theta}\mathcal{E}_{X}\mathcal{E}_{0}\ln f(y|x,\theta^{0})=\mathcal{E}_{X}\ma
 
 \end_inset
 
- The CLT
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-implies that 
+ The CLT implies that 
 \begin_inset Formula 
 \[
 \frac{1}{\sqrt{n}}\sum_{t=1}^{n}D_{\theta}\ln f(y|x,\theta^{0})\stackrel{d}{\rightarrow}N(0,\mathcal{I}_{\infty}(\theta^{0})).
@@ -68675,19 +67596,7 @@ The
 
 \begin_layout Itemize
 This shows that an AR(p) process is representable as an infinite-order MA(q)
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-process.
+ process.
 \end_layout
 
 \begin_layout Itemize
@@ -68725,20 +67634,7 @@ Y_{t}=F^{j+1}Y_{t-j-1}+F^{j}E_{t-j}+F^{j-1}E_{t-j+1}+\cdots+FE_{t-1}+E_{t}
 \begin_inset Formula $Y$
 \end_inset
 
- on the RHS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-drops out.
+ on the RHS drops out.
  The 
 \begin_inset Formula $E_{t-s}$
 \end_inset
@@ -68856,20 +67752,8 @@ c=\mu+\delta_{1}\mu+\delta_{2}\mu+...
 
 \end_inset
 
- So we see that an MA(q)
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
+ So we see that an MA(q) has an infinite AR representation, as long as the
  
-\end_layout
-
-\end_inset
-
-has an infinite AR representation, as long as the 
 \begin_inset Formula $|\eta_{i}|<1,$
 \end_inset
 
@@ -68939,21 +67823,8 @@ observationally equivalent
 \end_layout
 
 \begin_layout Itemize
-For a given MA(q)
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-process, it's always possible to manipulate the parameters to find an invertible
- representation (which is unique).
+For a given MA(q) process, it's always possible to manipulate the parameters
+ to find an invertible representation (which is unique).
 \end_layout
 
 \begin_layout Itemize
@@ -68989,20 +67860,7 @@ Why is invertibility important? The most important reason is that it provides
 \begin_inset Formula $\infty)$
 \end_inset
 
- processes have an AR(1)
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-representation.
+ processes have an AR(1) representation.
  Likewise, some AR(
 \begin_inset Formula $\infty)$
 \end_inset
@@ -69123,20 +67981,8 @@ where we have defined
 \end_layout
 
 \begin_layout Standard
-The asymptotic normality theorem above says that the GMM
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator using the optimal weighting matrix is distributed as 
+The asymptotic normality theorem above says that the GMM estimator using
+ the optimal weighting matrix is distributed as 
 \begin_inset Formula 
 \[
 \sqrt{n}\left(\hat{\theta}-\theta^{0}\right)\stackrel{d}{\rightarrow}N(0,V_{\infty})
@@ -77384,20 +76230,7 @@ s_{n}(\theta)=\frac{1}{n}\left[\mathbf{y}^{\prime}\mathbf{y}-2\mathbf{y}^{\prime
 \end_inset
 
  so the f.o.c.
- (with spherical errors)
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-simplify to 
+ (with spherical errors) simplify to 
 \begin_inset Formula 
 \[
 \mathbf{X}^{\prime}\mathbf{y}-\mathbf{X}^{\prime}\mathbf{X}\beta=0,
@@ -77405,40 +76238,14 @@ simplify to
 
 \end_inset
 
- the usual 0LS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-f.o.c.
+ the usual 0LS f.o.c.
 \end_layout
 
 \begin_layout Standard
 We can interpret this geometrically: 
 \shape italic
-INSERT
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-drawings of geometrical depiction of OLS and NLS (see Davidson and MacKinnon,
- pgs.
+INSERT drawings of geometrical depiction of OLS and NLS (see Davidson and
+ MacKinnon, pgs.
  8,13 and 46).
 \end_layout
 
@@ -77996,20 +76803,7 @@ s_{\infty}(\beta)=\mathcal{E}_{\mathbf{x}}\left(\exp(\mathbf{x}^{\prime}\beta^{0
 \begin_inset Formula $\beta=\beta^{0},$
 \end_inset
 
- so the NLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator is consistent as long as identification holds.
+ so the NLS estimator is consistent as long as identification holds.
 \end_layout
 
 \begin_layout Exercise
@@ -78175,20 +76969,7 @@ Note that one could estimate
 \begin_inset Formula $b$
 \end_inset
 
- simply by performing OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-on the above equation.
+ simply by performing OLS on the above equation.
 \end_layout
 
 \begin_layout Itemize
@@ -78219,20 +77000,7 @@ Given
 
 \begin_layout Standard
 To see why this might work, consider the above approximation, but evaluated
- at the NLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimator: 
+ at the NLS estimator: 
 \begin_inset Formula 
 \[
 \mathbf{y}=\mathbf{f}(\hat{\theta})+\mathbf{F}(\hat{\theta})\left(\theta-\hat{\theta}\right)+\omega
@@ -78240,20 +77008,7 @@ estimator:
 
 \end_inset
 
- The OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-estimate of 
+ The OLS estimate of 
 \begin_inset Formula $b\equiv\theta-\hat{\theta}$
 \end_inset
 
@@ -78326,34 +77081,8 @@ regressor matrix
 \end_inset
 
 ).
- In fact, a normal OLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-program will give the NLS
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-varcov estimator directly, since it's just the OLS varcov estimator from
- the last iteration.
+ In fact, a normal OLS program will give the NLS varcov estimator directly,
+ since it's just the OLS varcov estimator from the last iteration.
 \end_layout
 
 \begin_layout Itemize
@@ -79655,20 +78384,7 @@ The estimation subspace
 \end_inset
 
  .
- A
-\begin_inset ERT
-status collapsed
-
-\begin_layout Plain Layout
-
-
-\backslash
- 
-\end_layout
-
-\end_inset
-
-set of subsets 
+ A set of subsets 
 \begin_inset Formula $\mathcal{A}_{a}$
 \end_inset
 


### PR DESCRIPTION
These are a few organization commits. Feel free to tell me to stop messing with your document :). These are subjective, so if you like things the way they are, please reject.

The first commit removes preamble commands that do not affect the PDF output. I use a program called "diffpdf" that can do a pixel-by-pixel comparison to check that not just the text, but nothing about the display/size/spacing of the text changed. diffpdf is in the Ubuntu and Debian repositories (I forget which you use) in case you are interested.

The second commit moves the listings parameters from the preamble to the listings tab of Document Settings.

The third commit removes the ERT interword spaces that don't follow a colon. There were 102 of them. They don't affect the PDF output (confirmed by diffpdf). Most of them follow "OLS" or "IV".

There are still 16 interword spaces following colons. I left those since they do have an effect on PDF output. If you want, it might be possible to have a preamble command that basically says "a colon should be followed by an interword space" so you can centralize that, and you don't have to do it after each colon. Should I give that a shot or leave things as is? To be clear, I'm talking about instances like the following:

![interword-after-colon](https://github.com/mcreel/Econometrics/assets/1149353/8a2cb1d7-fdd3-4f7b-8014-b3b5c1662059)
