### PR TITLE
Restore missing label "subsec:MEPS data"

### DIFF
--- a/econometrics.lyx
+++ b/econometrics.lyx
@@ -34759,6 +34759,12 @@ approximate
 \end_layout
 
 \begin_layout Subsection
+\begin_inset CommandInset label
+LatexCommand label
+name "subsec:MEPS data"
+
+\end_inset
+
 Example:
  Maximum likelihood estimation using count data:
  The MEPS data and the Poisson model


### PR DESCRIPTION
There are six broken references that try to reference the (non-existent) label "subsec:MEPS data". This pull request adds the label where I think it should be (I checked this by looking a the "develop" branch, where the label does exist).

First, you should confirm that the label is indeed missing on your side. Navigate to the corresponding references, and they should be marked in red. Also, when you compile to PDF if you search the PDF for "??" you should see the places where the references are missing.

Unnecessary details (please feel free to skip): LyX did not use to mark these missing references as errors. We're currently preparing the LyX 2.5.0 release, and one of the decisions we've made is to mark these as errors, so now a dialog will show. Usually we only report an error if it is considered an error by LaTeX. But LaTeX has trouble knowing whether a missing reference is truly an error or whether it will be resolved on the next run of the LaTeX engine (since usually multiple LaTeX runs are needed). That's why LaTeX takes the conservative approach of marking them only as "warnings". LyX has the advantage of knowing which LaTeX run is indeed the last, so although there may be missing refs in the earlier runs that are indeed resolved later, any ref that is not resolved on the last run is now marked as an error. We were a little hesitant to flip the switch from a warning to an error since we know we'll get emails from users along the lines of "the new version broke my document!" even though the warnings (and symptoms of "??") have been there before, but it does seem to be the right thing to do. We'll see!